### PR TITLE
Avoid disable OMPT until XML is parsed

### DIFF
--- a/src/tracer/wrappers/OMP/ompt-wrapper.c
+++ b/src/tracer/wrappers/OMP/ompt-wrapper.c
@@ -66,7 +66,8 @@
 // interface operations
 //*****************************************************************************
 
-int ompt_enabled = FALSE;
+/* OMPT is disabled by default but this variable must be TRUE until XML is parsed */
+int ompt_enabled = TRUE;
 
 int (*ompt_set_callback_fn)(ompt_event_t, ompt_callback_t) = NULL;
 ompt_thread_id_t (*ompt_get_thread_id_fn)(void) = NULL;

--- a/src/tracer/xml-parse.c
+++ b/src/tracer/xml-parse.c
@@ -1749,6 +1749,7 @@ void Parse_XML_File (int rank, int world_size, const char *filename)
 							tracejant_omp = TRUE;
 							Parse_XML_OMP (rank, xmldoc, current_tag);
 
+							ompt_enabled = FALSE; /* OMPT is disabled by default */
 							xmlChar *ompt = xmlGetProp_env (rank, current_tag, TRACE_OMP_OMPT);
 							if (ompt != NULL && !xmlStrcasecmp (ompt, xmlYES))
 							{


### PR DESCRIPTION
Calls to ompt_initialize are ignored as they check the ompt_enabled variable to ensure user enabled OMPT support in the XML file. However, the XML file is not parsed (consequently, ompt_enabled variable is not properly set) untill the body of ompt_initialize is executed.

This PR closes issue #5.