### PR TITLE
add MPI library check for newer intel mpi distributions

### DIFF
--- a/config/mpi-macros.m4
+++ b/config/mpi-macros.m4
@@ -106,6 +106,9 @@ AC_DEFUN([AX_PROG_MPI],
          dnl Specific for BG/P machine
          elif test -f "${MPI_LIBSDIR}/libmpich.cnk.a" ; then
             MPI_LIBS="-lmpich.cnk"
+	 dnl check for newer impi
+         elif test -f "${MPI_LIBSDIR}/libmpi_ilp64.so" ; then
+            MPI_LIBS="-lmpi_ilp64"
          else
             MPI_LIBS="not found"
          fi


### PR DESCRIPTION
Over in openhpc land, we're seeing issues trying to build the latest extrae release with a 2019.x version of intel mpi. In this case, `configure` fails to complete due to being unable to detect the underlying MPI library (even though the path is resolved correctly). An example from our build system is below:

```
[ 2242s] checking mpi.h usability... yes
[ 2242s] checking mpi.h presence... yes
[ 2242s] checking for mpi.h... yes
[ 2242s] checking for MPICH2 defined... no
[ 2242s] checking for MPI library... /opt/intel/compilers_and_libraries_2019.2.187/linux/mpi/intel64/lib, not found
[ 2242s] configure: error: Cannot find MPI libraries file in the MPI specified path
```

The issue is that the macro does not check for the intel mpi library name (libmpi_ilp64.so).

This PR adds an additional check for this potential library name.