### PR TITLE
Make sure no process has 0 traces

### DIFF
--- a/src/merger/common/mpi2out.c
+++ b/src/merger/common/mpi2out.c
@@ -1074,15 +1074,17 @@ static void DistributeWork (unsigned num_processors, unsigned processor_id)
 
 	if (WorkDistribution == Block)
 	{
-		unsigned tasks_per_merger = (all_tasks + num_processors - 1) / num_processors;
+		unsigned offset = 0;
 		for (i=0; i<num_processors; i++)
 		{
-			for (j=0; j<tasks_per_merger; j++)
+			unsigned tasks_this_merger = (all_tasks / num_processors) + (i < all_tasks % num_processors ? 1 : 0);
+			for (j=0; j<tasks_this_merger; j++)
 			{
-				unsigned task_to_assign = (i * tasks_per_merger) + j;
+				unsigned task_to_assign = offset + j;
 				if (task_to_assign < all_tasks)
 					AssignFilesToWorker( i, all_tasks_ids[task_to_assign] );
 			}
+			offset += tasks_this_merger;
 		}
 	}
 	else if (WorkDistribution == Cyclic)


### PR DESCRIPTION
With 768 intermediate trace files, if "block" distribution is chosen for mpimpi2prv program with 40 processes, first 38 processes get 20 traces and 39th get 8 traces. The 40th process get none and that results in a crash.