### PR TITLE
Updated common.h to meet C++11 syntax

### DIFF
--- a/src/common/common.h
+++ b/src/common/common.h
@@ -86,7 +86,7 @@
 #define TEMPLATE_NODE_SEPARATOR_CHAR '@'
 
 #define TEMPLATE_DIGITS "%.10d%.6d%.6u"
-#define TEMPLATE_PTT    "%s/%s"TEMPLATE_NODE_SEPARATOR"%s."TEMPLATE_DIGITS"%s"  // dir/app@hostname.digits.ext
+#define TEMPLATE_PTT    "%s/%s" TEMPLATE_NODE_SEPARATOR "%s." TEMPLATE_DIGITS "%s"  // dir/app@hostname.digits.ext
 #define TEMPLATE_P      "%s/%s%s"
 
 /* Uses pid, task id and thread id to generate the name of the file */


### PR DESCRIPTION
My builds kept on failing, giving the following warning.  Tried messing around with the warnings level in the Makefile, but couldn't get it working.

```
CXX      papi_best_set-papi_best_set.o
In file included from papi_best_set.C:24:
../../src/common/common.h:89:32: error: invalid suffix on literal; C++11 requires a space
      between literal and identifier [-Wreserved-user-defined-literal]
#define TEMPLATE_PTT    "%s/%s"TEMPLATE_NODE_SEPARATOR"%s."TEMPLATE_DIGITS"%s"  // dir/...
                               ^
                                                                                               
../../src/common/common.h:89:60: error: invalid suffix on literal; C++11 requires a space
      between literal and identifier [-Wreserved-user-defined-literal]
#define TEMPLATE_PTT    "%s/%s"TEMPLATE_NODE_SEPARATOR"%s."TEMPLATE_DIGITS"%s"  // dir/...
                                                           ^
                                                                                               
2 errors generated.
make[3]: *** [Makefile:768: papi_best_set-papi_best_set.o] Error 1
make[3]: Leaving directory '/home/wheest/repos/extrae/src/others'
make[2]: *** [Makefile:646: all-recursive] Error 1
make[2]: Leaving directory '/home/wheest/repos/extrae/src'
make[1]: *** [Makefile:1114: all-recursive] Error 1
make[1]: Leaving directory '/home/wheest/repos/extrae'
make: *** [Makefile:1046: all] Error 2
```

However, the error was fixed by changing [this single line](https://github.com/bsc-performance-tools/extrae/blob/4c0fce71e35ac5f657abc8a64e01eee6a844054c/src/common/common.h#L89), and I was able to compile by just changing the definition to meet the C++11 syntax.

I reckon this won't change behavior for pre-C++11, and will avoid problems for folk in future. It seems simpler to do this rather than something that checks for a particular C++ version.