### PR TITLE
Compile java extrae for jdk version > 9

### DIFF
--- a/config/java.m4
+++ b/config/java.m4
@@ -49,9 +49,6 @@ AC_DEFUN([AX_JAVA],
 			if test -x "${java_path}/bin/javah" ; then
 				AC_MSG_RESULT(${java_path}/bin/javah)
 				JAVAH="${java_path}/bin/javah"
-				JAVAH_found="yes"
-			else
-				AC_MSG_ERROR([Java header and stub file generator was not found])
 			fi
 
 			AC_MSG_CHECKING([for Java archive tool])

--- a/src/java-connector/jni/Makefile.am
+++ b/src/java-connector/jni/Makefile.am
@@ -8,7 +8,10 @@ all: javatrace.jar
 
 javatrace.jar: es/bsc/cepbatools/extrae/Wrapper.java
 	$(JAVAC) $(BASE_DIR)/src/java-connector/jni/es/bsc/cepbatools/extrae/Wrapper.java -d .
-	$(JAVAH) -d $(JNI_INCLUDE_DIR) -jni es.bsc.cepbatools.extrae.Wrapper
+	ifdef JAVAH
+		$(JAVAH) -d $(JNI_INCLUDE_DIR) -jni es.bsc.cepbatools.extrae.Wrapper
+	else
+		$(JAVAC) -h $(JNI_INCLUDE_DIR) es/bsc/cepbatools/extrae/Wrapper.java
 	$(JAR) cvf javatrace.jar es/bsc/cepbatools/extrae/Wrapper.class 
 
 clean-local:


### PR DESCRIPTION
Added the possibility to compile javatrace when the [deprecated javah](https://openjdk.java.net/jeps/313) is not available.
