### PR TITLE
Javatrace: fixed bugs and added -jar option

### DIFF
--- a/config/java.m4
+++ b/config/java.m4
@@ -156,7 +156,7 @@ AC_DEFUN([AX_JAVA_ASPECTJ],
 
 	if test "${aspectj_ajc_found}" = "yes"; then
 
-		aspect_weaver_found="no"
+		aspectj_weaver_found="no"
 
 		if test "${aspectj_weaver_path}" = "no" ; then
 			AC_MSG_WARN([Java's AspectJ weaver support has been disabled])	
@@ -165,8 +165,12 @@ AC_DEFUN([AX_JAVA_ASPECTJ],
 			AC_MSG_NOTICE([--with-aspect-weaver was not given. Trying to automatically locate aspectweaver.jar])
 			if test -r "${aspectj_path}/share/java/aspectjweaver.jar" ; then
 				aspectj_weaver_path=${aspectj_path}/share/java
-			fi
-		else
+			elif test -r "${aspectj_path}/lib/aspectjweaver.jar" ; then
+                                aspectj_weaver_path=${aspectj_path}/lib
+                        fi
+		fi
+
+		if test "${aspectj_weaver_path}" != "none" ; then
 			AC_MSG_CHECKING([for AspectJ weaver directory])
 			if test -d "${aspectj_weaver_path}" ; then
 				AC_MSG_RESULT([found])

--- a/src/common/events.c
+++ b/src/common/events.c
@@ -164,12 +164,14 @@ unsigned IsPthread (unsigned EvType)
 /******************************************************************************
  ***  IsJava
  ******************************************************************************/
-#define JAVA_EVENTS 4
+#define JAVA_EVENTS 6
 static unsigned java_events[] = {
 	JAVA_JVMTI_GARBAGECOLLECTOR_EV,
 	JAVA_JVMTI_EXCEPTION_EV,
 	JAVA_JVMTI_OBJECT_ALLOC_EV,
-	JAVA_JVMTI_OBJECT_FREE_EV
+	JAVA_JVMTI_OBJECT_FREE_EV,
+	JAVA_JVMTI_THREAD_EV,
+	JAVA_JVMTI_WAIT_EV
 };
 
 unsigned IsJava (unsigned EvType)

--- a/src/common/events.h
+++ b/src/common/events.h
@@ -236,10 +236,13 @@ enum {
    MEMUSAGE_EVENTS_COUNT /* Total number of memusage events */
 };
 
-#define JAVA_JVMTI_GARBAGECOLLECTOR_EV     48000001
-#define JAVA_JVMTI_EXCEPTION_EV            48000002
-#define JAVA_JVMTI_OBJECT_ALLOC_EV         48000003
-#define JAVA_JVMTI_OBJECT_FREE_EV          48000004
+#define JAVA_JVMTI_GARBAGECOLLECTOR_EV      48000001
+#define JAVA_JVMTI_EXCEPTION_EV             48000002
+#define JAVA_JVMTI_OBJECT_ALLOC_EV          48000003
+#define JAVA_JVMTI_OBJECT_FREE_EV           48000004
+#define JAVA_JVMTI_THREAD_EV                48000005
+#define JAVA_JVMTI_WAIT_EV                  48000006
+
 
 #define OMP_STATS_BASE           65000000
 enum {

--- a/src/java-connector/jvmti-agent/extrae-jvmti-agent.c
+++ b/src/java-connector/jvmti-agent/extrae-jvmti-agent.c
@@ -43,11 +43,25 @@
 #include "java_probe.h"
 
 #define CHECK_JVMTI_ERROR(x,call) \
-	{ if (x != JVMTI_ERROR_NONE) { fprintf (stderr, PACKAGE_NAME": Error during %s in %s:%d\n", #call, __FILE__, __LINE__); } }
+	{ if (x != JVMTI_ERROR_NONE) { fprintf (stderr, PACKAGE_NAME": Error %u during %s in %s:%d\n", x, #call, __FILE__, __LINE__); } }
 
 /* Global static data */
 static jvmtiEnv     *jvmti;
 static jrawMonitorID ExtraeJ_AgentLock;
+
+static void Extraej_NotifyNewThread(void)
+{
+    //Backend_CreatepThreadIdentifier();
+
+    if (!Extrae_get_pthread_tracing())
+        Backend_NotifyNewPthread();
+}
+
+static void Extraej_FlushThread(void)
+{
+    if (!Extrae_get_pthread_tracing())
+        Backend_Flush_pThread(pthread_self());
+}
 
 /* Callback for JVMTI_EVENT_GARBAGE_COLLECTION_START */
 static void JNICALL Extraej_cb_GarbageCollector_begin (jvmtiEnv* jvmti_env)
@@ -60,9 +74,11 @@ static void JNICALL Extraej_cb_GarbageCollector_begin (jvmtiEnv* jvmti_env)
 /* Callback for JVMTI_EVENT_GARBAGE_COLLECTION_FINISH */
 static void JNICALL Extraej_cb_GarbageCollector_end(jvmtiEnv* jvmti_env)
 {
+    jvmtiThreadInfo ti;
+    jvmtiError r;
 	UNREFERENCED_PARAMETER(jvmti_env);
 
-	Extrae_Java_GarbageCollector_end();
+    Extrae_Java_GarbageCollector_end();
 }
 
 #if 0
@@ -102,7 +118,7 @@ static void JNICALL Extraej_cb_Exception (jvmtiEnv *jvmti_env, JNIEnv* jni_env,
 	UNREFERENCED_PARAMETER(catch_method);
 	UNREFERENCED_PARAMETER(catch_location);
 
-	Extrae_Java_Exception_begin();
+    Extrae_Java_Exception_begin();
 }
 
 static void JNICALL Extraej_cb_ExceptionCatch (jvmtiEnv *jvmti_env,
@@ -116,25 +132,99 @@ static void JNICALL Extraej_cb_ExceptionCatch (jvmtiEnv *jvmti_env,
 	UNREFERENCED_PARAMETER(location);
 	UNREFERENCED_PARAMETER(exception);
 
-	Extrae_Java_Exception_end();
+    Extrae_Java_Exception_end();
 }
 
-static void JNICALL Extraej_cb_ThreadStart (jvmtiEnv *jvmti_env,
+static void JNICALL Extraej_cb_Thread_start (jvmtiEnv *jvmti_env,
 	JNIEnv* jni_env, jthread thread)
 {
-/*
+
 	jvmtiThreadInfo ti;
 	jvmtiError r;
 	UNREFERENCED_PARAMETER(jni_env);
 
-	if (thread != NULL)
-	{
-		r = (*jvmti_env)->GetThreadInfo(jvmti_env, thread, &ti);
-		if (r == JVMTI_ERROR_NONE)
-			Extrae_set_thread_name (THREADID, ti.name);
-	}
-*/
+    if (thread != NULL)
+    {
+        r = (*jvmti_env)->GetThreadInfo(jvmti_env, thread, &ti);
+
+        //Apparently, when thread is ending, ThreadStart is called with thread_group=0
+        if (r == JVMTI_ERROR_NONE && ti.thread_group){
+            Extraej_NotifyNewThread();
+
+            unsigned threadid = THREADID;
+            if (strcmp("", Extrae_get_thread_name(threadid)) == 0)
+                Extrae_set_thread_name(threadid, ti.name);
+
+            Extrae_Java_Thread_start();
+        }
+    }
+
 }
+
+static void JNICALL Extraej_cb_Thread_end (jvmtiEnv *jvmti_env,
+        JNIEnv* jni_env, jthread thread)
+{
+    UNREFERENCED_PARAMETER(jni_env);
+
+    Extrae_Java_Thread_end();
+
+    Extraej_FlushThread();
+}
+
+static void JNICALL Extraej_cb_Monitor_wait(jvmtiEnv *jvmti_env,
+        JNIEnv* jni_env, jthread thread, jobject object, jlong timeout)
+{
+    UNREFERENCED_PARAMETER(jvmti_env);
+    UNREFERENCED_PARAMETER(jni_env);
+    UNREFERENCED_PARAMETER(thread);
+    UNREFERENCED_PARAMETER(object);
+
+    Extrae_Java_Wait_start();
+}
+
+static void JNICALL Extraej_cb_Monitor_waited(jvmtiEnv *jvmti_env,
+        JNIEnv* jni_env, jthread thread, jobject object, jboolean timed_out)
+{
+    UNREFERENCED_PARAMETER(jvmti_env);
+    UNREFERENCED_PARAMETER(jni_env);
+    UNREFERENCED_PARAMETER(thread);
+    UNREFERENCED_PARAMETER(object);
+
+    Extrae_Java_Wait_end();
+}
+
+static void JNICALL Extraej_cb_MonitorContended_enter(jvmtiEnv *jvmti_env,
+        JNIEnv* jni_env, jthread thread, jobject object)
+{
+    UNREFERENCED_PARAMETER(jvmti_env);
+    UNREFERENCED_PARAMETER(jni_env);
+    UNREFERENCED_PARAMETER(thread);
+    UNREFERENCED_PARAMETER(object);
+
+
+    Extraej_cb_Monitor_wait(jvmti_env, jni_env, thread, object, 0);
+}
+
+
+static void JNICALL Extraej_cb_MonitorContended_entered(jvmtiEnv *jvmti_env,
+        JNIEnv* jni_env, jthread thread, jobject object)
+{
+    UNREFERENCED_PARAMETER(jvmti_env);
+    UNREFERENCED_PARAMETER(jni_env);
+    UNREFERENCED_PARAMETER(thread);
+    UNREFERENCED_PARAMETER(object);
+
+    Extraej_cb_Monitor_waited(jvmti_env, jni_env, thread, object, FALSE);
+}
+
+#if 0
+static void JNICALL Extraej_cb_MonitorNotify(jvmtiEnv *jvmti_env,
+        JNIEnv* jni_env, jthread thread, jmethodID method, jboolean was_popped_by_exception)
+{
+
+}
+#endif
+
 
 JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM *vm, char *options, void *reserved)
 {
@@ -159,6 +249,8 @@ JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM *vm, char *options, void *reserved)
     capabilities.can_generate_garbage_collection_events = 1;
 	capabilities.can_generate_exception_events = 1;
 	capabilities.can_tag_objects = 1;
+    capabilities.can_generate_monitor_events = 1;
+
 #if 0
 	capabilities.can_generate_vm_object_alloc_events = 1;
 	capabilities.can_generate_object_free_events = 1;
@@ -176,7 +268,12 @@ JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM *vm, char *options, void *reserved)
     callbacks.VMObjectAlloc           = &Extraej_cb_ObjectAlloc;
     callbacks.ObjectFree              = &Extreaj_cb_ObjectFree;
 #endif
-	callbacks.ThreadStart             = &Extraej_cb_ThreadStart;
+	callbacks.ThreadStart             = &Extraej_cb_Thread_start;
+	callbacks.ThreadEnd               = &Extraej_cb_Thread_end;
+	callbacks.MonitorWait             = &Extraej_cb_Monitor_wait;
+	callbacks.MonitorWaited           = &Extraej_cb_Monitor_waited;
+	callbacks.MonitorContendedEnter   = &Extraej_cb_MonitorContended_enter;
+	callbacks.MonitorContendedEntered = &Extraej_cb_MonitorContended_entered;
 
     r = (*jvmti)->SetEventCallbacks(jvmti, &callbacks, sizeof(callbacks));
 	CHECK_JVMTI_ERROR(r, SetEventCallbacks);
@@ -207,10 +304,36 @@ JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM *vm, char *options, void *reserved)
 	  JVMTI_EVENT_EXCEPTION_CATCH, NULL);
     CHECK_JVMTI_ERROR(r, SetEventNotificationMode);
 
-	/* Thread start */
-	r = (*jvmti)->SetEventNotificationMode(jvmti, JVMTI_ENABLE,
-	  JVMTI_EVENT_THREAD_START, NULL);
+    /* Thread start */
+    r = (*jvmti)->SetEventNotificationMode(jvmti, JVMTI_ENABLE,
+                                           JVMTI_EVENT_THREAD_START, NULL);
     CHECK_JVMTI_ERROR(r, SetEventNotificationMode);
+
+    /* Thread end */
+    r = (*jvmti)->SetEventNotificationMode(jvmti, JVMTI_ENABLE,
+                                           JVMTI_EVENT_THREAD_END, NULL);
+    CHECK_JVMTI_ERROR(r, SetEventNotificationMode);
+
+    /* Monitor Wait */
+    r = (*jvmti)->SetEventNotificationMode(jvmti, JVMTI_ENABLE,
+                                           JVMTI_EVENT_MONITOR_WAIT, NULL);
+    CHECK_JVMTI_ERROR(r, SetEventNotificationMode);
+
+    /* Monitor Waited */
+    r = (*jvmti)->SetEventNotificationMode(jvmti, JVMTI_ENABLE,
+                                           JVMTI_EVENT_MONITOR_WAITED, NULL);
+    CHECK_JVMTI_ERROR(r, SetEventNotificationMode);
+
+    /* Contended Monitor Enter */
+    r = (*jvmti)->SetEventNotificationMode(jvmti, JVMTI_ENABLE,
+                                           JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL);
+    CHECK_JVMTI_ERROR(r, SetEventNotificationMode);
+
+    /* Contended Monitor Entered */
+    r = (*jvmti)->SetEventNotificationMode(jvmti, JVMTI_ENABLE,
+                                           JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL);
+    CHECK_JVMTI_ERROR(r, SetEventNotificationMode);
+
 
     /* Create the necessary raw monitor ?? really, necessary? */
     r = (*jvmti)->CreateRawMonitor(jvmti, "ExtraeJ_AgentLock", &ExtraeJ_AgentLock);

--- a/src/launcher/java/Makefile.am
+++ b/src/launcher/java/Makefile.am
@@ -8,6 +8,7 @@ extraej.bash: extraej.bash.skeleton
 	$(top_srcdir)/substitute $(SED) "@sub_JAVA@" "${JAVA}" $@
 	$(top_srcdir)/substitute $(SED) "@sub_AJC@" "${AJC}" $@
 	$(top_srcdir)/substitute $(SED) "@sub_ASPECTWEAVER_JAR@" "${ASPECT_WEAVER_JAR}"  $@
+	$(top_srcdir)/substitute $(SED) "@sub_ASPECTJRT_JAR@" "${ASPECTJRT_JAR}" $@
 	$(top_srcdir)/substitute $(SED) "@sub_PREFIXDIR@" "${prefix}" $@
 
 install-data-hook: extraej.bash

--- a/src/launcher/java/Makefile.am
+++ b/src/launcher/java/Makefile.am
@@ -7,7 +7,7 @@ extraej.bash: extraej.bash.skeleton
 	cp -v $^ $@
 	$(top_srcdir)/substitute $(SED) "@sub_JAVA@" "${JAVA}" $@
 	$(top_srcdir)/substitute $(SED) "@sub_AJC@" "${AJC}" $@
-	$(top_srcdir)/substitute $(SED) "@sub_ASPECTWEAVER_JAR@" $@
+	$(top_srcdir)/substitute $(SED) "@sub_ASPECTWEAVER_JAR@" "${ASPECT_WEAVER_JAR}"  $@
 	$(top_srcdir)/substitute $(SED) "@sub_PREFIXDIR@" "${prefix}" $@
 
 install-data-hook: extraej.bash

--- a/src/launcher/java/extraej.bash.skeleton
+++ b/src/launcher/java/extraej.bash.skeleton
@@ -225,6 +225,8 @@ application_separator_found="no"
 JAVA=@sub_JAVA@
 AJC=@sub_AJC@
 ASPECTWEAVER_JAR=@sub_ASPECTWEAVER_JAR@
+ASPECTJRT_JAR=@sub_ASPECTJRT_JAR@
+
 
 # Check existance for config file pointed by EXTRAE_CONFIG_FILE
 
@@ -286,10 +288,10 @@ if [[ -x "${AJC}" ]]; then
 			generate_aspects
 		
 			if [[ "${verbose}" = "yes" ]]; then
-				echo "Executing: CLASSPATH=${ASPECTWEAVER_JAR}:${EXTRAEJ_JAVATRACE_PATH}:${CLASSPATH} ${AJC} -inpath . -sourceroots ${tmpdir}/aspects -d ${tmpdir}/instrumented"
+				echo "Executing: CLASSPATH=${ASPECTJRT_JAR}:${ASPECTWEAVER_JAR}:${EXTRAEJ_JAVATRACE_PATH}:${CLASSPATH} ${AJC} -inpath . -sourceroots ${tmpdir}/aspects -d ${tmpdir}/instrumented"
 			fi
 		
-			CLASSPATH=${ASPECTWEAVER_JAR}:${EXTRAEJ_JAVATRACE_PATH}:${CLASSPATH} \
+			CLASSPATH=${ASPECTJRT_JAR}:${ASPECTWEAVER_JAR}:${EXTRAEJ_JAVATRACE_PATH}:${CLASSPATH} \
 			${AJC} \
 			 -inpath . \
 			 -sourceroots ${tmpdir}/aspects \
@@ -298,7 +300,7 @@ if [[ -x "${AJC}" ]]; then
 				die "Error! ${AJC} failed"
 			fi
 
-			execute_java ${tmpdir}/instrumented:${ASPECTWEAVER_JAR}:${CLASSPATH} \
+			execute_java ${tmpdir}/instrumented:${ASPECTJRT_JAR}:${ASPECTWEAVER_JAR}:${CLASSPATH} \
 				${EXTRAEJ_LIBPTTRACE_PATH} \
 				"$@"
 		else
@@ -320,7 +322,7 @@ if [[ -x "${AJC}" ]]; then
 		fi
 
 		# Let's execute the code with Extrae support
-		execute_java ${reuse_dir}/instrumented:${ASPECTWEAVER_JAR}:${CLASSPATH} \
+		execute_java ${reuse_dir}/instrumented:${ASPECTJRT_JAR}:${ASPECTWEAVER_JAR}:${CLASSPATH} \
 			${EXTRAEJ_LIBPTTRACE_PATH} \
 			"$@"
 	fi

--- a/src/launcher/java/extraej.bash.skeleton
+++ b/src/launcher/java/extraej.bash.skeleton
@@ -161,9 +161,11 @@ parse_parameters () {
 			keep_instrumented_files="yes"
 		elif [[ "${1}" = "-v" ]]; then
 			verbose="yes"
-		elif [[ "${1}" = "-reuse" ]] ; then
+		elif [[ "${1}" = "-reuse" ]]; then
 			shift
 			reuse_dir=${1}
+		elif [[ "${1}" = "-jar" ]]; then
+			jarmode="yes"
 		elif [[ "${1}" = "--" ]]; then
 			application_separator_found="yes"
 			break
@@ -181,6 +183,11 @@ execute_java () {
 	shift
 	local preload=$1
 	shift
+	local options=""
+
+	if [[ "${jarmode}" = "yes" ]]; then
+		options=-jar
+	fi
 
 	# Check whether Extrae supported JVMTI
 	if [[ ! -r ${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH} ]]; then
@@ -191,7 +198,7 @@ execute_java () {
 		LD_LIBRARY_PATH=`dirname ${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH}`:${LD_LIBRARY_PATH} \
 		LD_PRELOAD=${preload} \
 		CLASSPATH=${cp} \
-		  ${JAVA} ${@}
+		  ${JAVA} ${options} ${@}
 	else
 		local agent=${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH}
 
@@ -202,7 +209,7 @@ execute_java () {
 		LD_LIBRARY_PATH=`dirname ${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH}`:${LD_LIBRARY_PATH} \
 		LD_PRELOAD=${preload} \
 		CLASSPATH=${cp} \
-		  ${JAVA} -agentpath:${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH} ${@}
+		  ${JAVA} ${options} -agentpath:${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH} ${@}
 	fi
 }
 
@@ -217,6 +224,7 @@ extrae_function_list_enabled=""
 MemberArray=()
 keep_instrumented_files="no"
 verbose="no"
+jarmode="no"
 reuse_dir=""
 application_separator_found="no"
 
@@ -233,15 +241,17 @@ ASPECTJRT_JAR=@sub_ASPECTJRT_JAR@
 if [[ "${#}" -eq 0 ]]; then
 	echo "Usage for Extrae/Java-based instrumenter:"
 	echo ""
-	echo "  "`basename ${0}`" {options} -- <JavaMethod>"
+	echo "  "`basename ${0}`" {options} -- <JavaTarget>"
 	echo ""
 	echo "  where options:"
 	echo "    -v           Makes execution verbose"
-    echo "    -keep        Runs and saves the instrumented package for a future use"
-    echo "    -reuse <dir> Tells "`basename ${0}`" to reuse a previously instrumented package saved through -keep"
+	echo "    -keep        Runs and saves the instrumented package for a future use"
+	echo "    -reuse <dir> Tells "`basename ${0}`" to reuse a previously instrumented package saved through -keep"
+	echo "    -jar         Runs the target as a jar file"
 	echo
-	echo " Example:"
+	echo " Examples:"
 	echo "  \$\{EXTRAE_HOME\}/bin/"`basename ${0}`" -v -keep -- PiExample"
+	echo "  \$\{EXTRAE_HOME\}/bin/"`basename ${0}`" -v -jar -- PiExample.jar"
 	echo
 	echo " Note: Remember to indicate the configuration file through the EXTRAE_CONFIG_FILE environment variable"
 	die ""

--- a/src/launcher/java/extraej.bash.skeleton
+++ b/src/launcher/java/extraej.bash.skeleton
@@ -165,7 +165,8 @@ parse_parameters () {
 			shift
 			reuse_dir=${1}
 		elif [[ "${1}" = "-jar" ]]; then
-			jarmode="yes"
+			shift
+            jartarget=${1}
 		elif [[ "${1}" = "--" ]]; then
 			application_separator_found="yes"
 			break
@@ -183,33 +184,30 @@ execute_java () {
 	shift
 	local preload=$1
 	shift
-	local options=""
-
-	if [[ "${jarmode}" = "yes" ]]; then
-		options=-jar
-	fi
 
 	# Check whether Extrae supported JVMTI
 	if [[ ! -r ${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH} ]]; then
 		if [[ "${verbose}" = "yes" ]]; then
-			echo "Executing: LD_LIBRARY_PATH=`dirname ${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH}`:\${LD_LIBRARY_PATH} LD_PRELOAD=${preload} CLASSPATH=${cp} ${JAVA} ${@}"
+			echo "Executing: LD_LIBRARY_PATH=`dirname ${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH}`:\
+                ${LD_LIBRARY_PATH} LD_PRELOAD=${preload} CLASSPATH=${cp} ${JAVA} ${@}"
 		fi
 
 		LD_LIBRARY_PATH=`dirname ${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH}`:${LD_LIBRARY_PATH} \
 		LD_PRELOAD=${preload} \
 		CLASSPATH=${cp} \
-		  ${JAVA} ${options} ${@}
+		  ${JAVA} ${@}
 	else
 		local agent=${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH}
 
 		if [[ "${verbose}" = "yes" ]]; then
-			echo "Executing: LD_LIBRARY_PATH=`dirname ${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH}`:\${LD_LIBRARY_PATH} LD_PRELOAD=${preload} CLASSPATH=${cp} ${JAVA} -agentpath:${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH} ${@}"
+			echo "Executing: LD_LIBRARY_PATH=`dirname ${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH}`:\
+                ${LD_LIBRARY_PATH} LD_PRELOAD=${preload} CLASSPATH=${cp} ${JAVA} -agentpath:${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH} ${@}"
 		fi
 
 		LD_LIBRARY_PATH=`dirname ${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH}`:${LD_LIBRARY_PATH} \
 		LD_PRELOAD=${preload} \
 		CLASSPATH=${cp} \
-		  ${JAVA} ${options} -agentpath:${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH} ${@}
+		  ${JAVA} -agentpath:${EXTRAEJ_LIBEXTRAEJVMTIAGENT_PATH} ${@}
 	fi
 }
 
@@ -224,7 +222,7 @@ extrae_function_list_enabled=""
 MemberArray=()
 keep_instrumented_files="no"
 verbose="no"
-jarmode="no"
+jartarget=""
 reuse_dir=""
 application_separator_found="no"
 
@@ -251,7 +249,7 @@ if [[ "${#}" -eq 0 ]]; then
 	echo
 	echo " Examples:"
 	echo "  \$\{EXTRAE_HOME\}/bin/"`basename ${0}`" -v -keep -- PiExample"
-	echo "  \$\{EXTRAE_HOME\}/bin/"`basename ${0}`" -v -jar -- PiExample.jar"
+	echo "  \$\{EXTRAE_HOME\}/bin/"`basename ${0}`" -v -jar PiExample.jar -- PiExample"
 	echo
 	echo " Note: Remember to indicate the configuration file through the EXTRAE_CONFIG_FILE environment variable"
 	die ""
@@ -283,6 +281,10 @@ do
 	shift
 done
 
+if [[ "${jartarget}" != "" ]]; then
+        CLASSPATH=${jartarget}:${CLASSPATH}
+fi
+
 # Do we support AspectJ?
 if [[ -x "${AJC}" ]]; then
 
@@ -296,14 +298,21 @@ if [[ -x "${AJC}" ]]; then
 			tmpdir=`mktemp -d extraej.XXXXXX`
 
 			generate_aspects
+
+            if [[ "${jartarget}" != "" ]]; then
+                inpath=${jartarget}
+            else
+                inpath=.
+            fi
 		
 			if [[ "${verbose}" = "yes" ]]; then
-				echo "Executing: CLASSPATH=${ASPECTJRT_JAR}:${ASPECTWEAVER_JAR}:${EXTRAEJ_JAVATRACE_PATH}:${CLASSPATH} ${AJC} -inpath . -sourceroots ${tmpdir}/aspects -d ${tmpdir}/instrumented"
+				echo "Executing: CLASSPATH=${ASPECTJRT_JAR}:${ASPECTWEAVER_JAR}:${EXTRAEJ_JAVATRACE_PATH}:${CLASSPATH} \
+                    ${AJC} -inpath ${inpath} -sourceroots ${tmpdir}/aspects -d ${tmpdir}/instrumented"
 			fi
 		
 			CLASSPATH=${ASPECTJRT_JAR}:${ASPECTWEAVER_JAR}:${EXTRAEJ_JAVATRACE_PATH}:${CLASSPATH} \
 			${AJC} \
-			 -inpath . \
+			 -inpath ${inpath} \
 			 -sourceroots ${tmpdir}/aspects \
 			 -d ${tmpdir}/instrumented
 			if [[ "${?}" -ne 0 ]]; then

--- a/src/launcher/java/extraej.bash.skeleton
+++ b/src/launcher/java/extraej.bash.skeleton
@@ -239,7 +239,7 @@ ASPECTJRT_JAR=@sub_ASPECTJRT_JAR@
 if [[ "${#}" -eq 0 ]]; then
 	echo "Usage for Extrae/Java-based instrumenter:"
 	echo ""
-	echo "  "`basename ${0}`" {options} -- <JavaTarget>"
+	echo "  "`basename ${0}`" {options} -- <JavaClass>"
 	echo ""
 	echo "  where options:"
 	echo "    -v           Makes execution verbose"

--- a/src/merger/paraver/java_prv_events.c
+++ b/src/merger/paraver/java_prv_events.c
@@ -41,8 +41,10 @@
 #define JAVA_JVMTI_EXCEPTION_INDEX        1
 #define JAVA_JVMTI_OBJECT_ALLOC_INDEX     2
 #define JAVA_JVMTI_OBJECT_FREE_INDEX      3
+#define JAVA_JVMTI_THREAD_INDEX           4
+#define JAVA_JVMTI_WAIT_INDEX             5
 
-#define MAX_JAVA_INDEX                    4
+#define MAX_JAVA_INDEX                    6
 
 static int inuse[MAX_JAVA_INDEX] = { FALSE };
 
@@ -51,7 +53,9 @@ void Enable_Java_Operation (int type)
 	ENABLE_JAVA_EVENT(type, JAVA_JVMTI_GARBAGECOLLECTOR);
 	ENABLE_JAVA_EVENT(type, JAVA_JVMTI_EXCEPTION);
 	ENABLE_JAVA_EVENT(type, JAVA_JVMTI_OBJECT_ALLOC);
-	ENABLE_JAVA_EVENT(type, JAVA_JVMTI_OBJECT_FREE);
+    ENABLE_JAVA_EVENT(type, JAVA_JVMTI_OBJECT_FREE);
+    ENABLE_JAVA_EVENT(type, JAVA_JVMTI_THREAD);
+    ENABLE_JAVA_EVENT(type, JAVA_JVMTI_WAIT);
 }
 
 #if defined(PARALLEL_MERGE)
@@ -95,6 +99,16 @@ void JavaEvent_WriteEnabledOperations (FILE * fd)
 	if (inuse[JAVA_JVMTI_OBJECT_FREE_INDEX])
 	{
 		fprintf (fd, "EVENT_TYPE\n%d %d Java object free\n\n", 0, JAVA_JVMTI_OBJECT_FREE_EV);
+	}
+
+	if (inuse[JAVA_JVMTI_THREAD_INDEX])
+	{
+		fprintf (fd, "EVENT_TYPE\n%d %d Java thread running\n\n", 0, JAVA_JVMTI_THREAD_EV);
+	}
+
+	if (inuse[JAVA_JVMTI_WAIT_INDEX])
+	{
+		fprintf (fd, "EVENT_TYPE\n%d %d Java thread waiting in join\n\n", 0, JAVA_JVMTI_WAIT_EV);
 	}
 }
 

--- a/src/merger/paraver/java_prv_semantics.c
+++ b/src/merger/paraver/java_prv_semantics.c
@@ -61,6 +61,12 @@ static int JAVA_JVMTI_call (event_t* event, unsigned long long current_time,
 			state = STATE_OTHERS;
 			Switch_State (state, (EvValue != EVT_END), ptask, task, thread);
 			break;
+		case JAVA_JVMTI_THREAD_EV:
+        		Switch_State (STATE_RUNNING, (EvValue != EVT_END), ptask, task, thread);
+			break;
+		case JAVA_JVMTI_WAIT_EV:
+        		Switch_State (STATE_SYNC, (EvValue != EVT_END), ptask, task, thread);
+			break;
 	}
 
 	trace_paraver_state (cpu, ptask, task, thread, current_time);
@@ -75,6 +81,8 @@ SingleEv_Handler_t PRV_Java_Event_Handlers[] = {
 	{ JAVA_JVMTI_EXCEPTION_EV, JAVA_JVMTI_call },
 	{ JAVA_JVMTI_OBJECT_ALLOC_EV, JAVA_JVMTI_call },
 	{ JAVA_JVMTI_OBJECT_FREE_EV, JAVA_JVMTI_call },
+	{ JAVA_JVMTI_THREAD_EV, JAVA_JVMTI_call },
+	{ JAVA_JVMTI_WAIT_EV, JAVA_JVMTI_call },
 	{ NULL_EV, NULL }
 };
 

--- a/src/tracer/wrappers/JAVA/java_probe.c
+++ b/src/tracer/wrappers/JAVA/java_probe.c
@@ -26,14 +26,83 @@
 #include "threadid.h"
 #include "wrapper.h"
 #include "trace_macros.h"
+
 #include "java_probe.h"
+
+#if 0
+# define DEBUG fprintf (stdout, "THREAD %d: %s\n", THREADID, __FUNCTION__);
+#else
+# define DEBUG
+#endif
+
+void Extrae_Java_Thread_start(void)
+{
+    if(! EXTRAE_ON()) return;
+
+    if (EXTRAE_INITIALIZED() && !Extrae_get_pthread_tracing())
+    {
+        Backend_Enter_Instrumentation ();
+
+        DEBUG
+        TRACE_MISCEVENTANDCOUNTERS(LAST_READ_TIME, JAVA_JVMTI_THREAD_EV, EVT_BEGIN, EMPTY);
+        Extrae_AnnotateCPU (LAST_READ_TIME);
+
+        Backend_Leave_Instrumentation ();
+    }
+}
+
+void Extrae_Java_Thread_end(void)
+{
+    if(! EXTRAE_ON()) return;
+
+    if (EXTRAE_INITIALIZED() && !Extrae_get_pthread_tracing())
+    {
+        DEBUG
+        TRACE_MISCEVENTANDCOUNTERS(TIME, JAVA_JVMTI_THREAD_EV, EVT_END, EMPTY)
+        Extrae_AnnotateCPU (LAST_READ_TIME);
+
+        Backend_Leave_Instrumentation ();
+    }
+}
+
+void Extrae_Java_Wait_start(void)
+{
+    if(! EXTRAE_ON()) return;
+
+    if (EXTRAE_INITIALIZED())
+    {
+        Backend_Enter_Instrumentation ();
+
+        DEBUG
+        if (!Extrae_get_pthread_tracing())
+            TRACE_MISCEVENTANDCOUNTERS(LAST_READ_TIME, JAVA_JVMTI_WAIT_EV, EVT_BEGIN, EMPTY)
+        else
+            TRACE_PTHEVENTANDCOUNTERS(LAST_READ_TIME, PTHREAD_JOIN_EV, EVT_BEGIN, EMPTY)
+    }
+}
+
+void Extrae_Java_Wait_end(void)
+{
+    if(! EXTRAE_ON()) return;
+
+    if (EXTRAE_INITIALIZED())
+    {
+        DEBUG
+        if (!Extrae_get_pthread_tracing())
+            TRACE_MISCEVENTANDCOUNTERS(TIME, JAVA_JVMTI_WAIT_EV, EVT_END, EMPTY)
+        else
+            TRACE_PTHEVENTANDCOUNTERS(TIME, PTHREAD_JOIN_EV, EVT_END, EMPTY)
+
+        Backend_Leave_Instrumentation ();
+    }
+}
 
 void Extrae_Java_GarbageCollector_begin(void)
 {
 	if (EXTRAE_ON())
 	{
 		Backend_Enter_Instrumentation ();
-		TRACE_MISCEVENTANDCOUNTERS(LAST_READ_TIME,
+                TRACE_MISCEVENTANDCOUNTERS(LAST_READ_TIME,
 		  JAVA_JVMTI_GARBAGECOLLECTOR_EV,
 		  EVT_BEGIN,
 		  EMPTY);
@@ -44,7 +113,7 @@ void Extrae_Java_GarbageCollector_end(void)
 {
 	if (EXTRAE_ON())
 	{
-		TRACE_MISCEVENTANDCOUNTERS(TIME,
+                TRACE_MISCEVENTANDCOUNTERS(TIME,
 		  JAVA_JVMTI_GARBAGECOLLECTOR_EV,
 		  EVT_END,
 		  EMPTY);
@@ -57,7 +126,7 @@ void Extrae_Java_Exception_begin(void)
 	if (EXTRAE_ON())
 	{
 		Backend_Enter_Instrumentation ();
-		TRACE_MISCEVENTANDCOUNTERS(LAST_READ_TIME,
+                TRACE_PTHEVENTANDCOUNTERS(LAST_READ_TIME,
 		  JAVA_JVMTI_EXCEPTION_EV,
 		  EVT_BEGIN,
 		  EMPTY);
@@ -68,7 +137,7 @@ void Extrae_Java_Exception_end(void)
 {
 	if (EXTRAE_ON())
 	{
-		TRACE_MISCEVENTANDCOUNTERS(TIME,
+                TRACE_PTHEVENTANDCOUNTERS(TIME,
 		  JAVA_JVMTI_EXCEPTION_EV,
 		  EVT_END,
 		  EMPTY);

--- a/src/tracer/wrappers/JAVA/java_probe.c
+++ b/src/tracer/wrappers/JAVA/java_probe.c
@@ -74,10 +74,7 @@ void Extrae_Java_Wait_start(void)
         Backend_Enter_Instrumentation ();
 
         DEBUG
-        if (!Extrae_get_pthread_tracing())
-            TRACE_MISCEVENTANDCOUNTERS(LAST_READ_TIME, JAVA_JVMTI_WAIT_EV, EVT_BEGIN, EMPTY)
-        else
-            TRACE_PTHEVENTANDCOUNTERS(LAST_READ_TIME, PTHREAD_JOIN_EV, EVT_BEGIN, EMPTY)
+        TRACE_MISCEVENTANDCOUNTERS(LAST_READ_TIME, JAVA_JVMTI_WAIT_EV, EVT_BEGIN, EMPTY)
     }
 }
 
@@ -88,10 +85,7 @@ void Extrae_Java_Wait_end(void)
     if (EXTRAE_INITIALIZED())
     {
         DEBUG
-        if (!Extrae_get_pthread_tracing())
-            TRACE_MISCEVENTANDCOUNTERS(TIME, JAVA_JVMTI_WAIT_EV, EVT_END, EMPTY)
-        else
-            TRACE_PTHEVENTANDCOUNTERS(TIME, PTHREAD_JOIN_EV, EVT_END, EMPTY)
+        TRACE_MISCEVENTANDCOUNTERS(TIME, JAVA_JVMTI_WAIT_EV, EVT_END, EMPTY)
 
         Backend_Leave_Instrumentation ();
     }

--- a/src/tracer/wrappers/JAVA/java_probe.h
+++ b/src/tracer/wrappers/JAVA/java_probe.h
@@ -24,6 +24,11 @@
 #ifndef PROBE_JAVA_H_INCLUDED
 #define PROBE_JAVA_H_INCLUDED
 
+void Extrae_Java_Thread_start(void);
+void Extrae_Java_Thread_end(void);
+void Extrae_Java_Wait_start(void);
+void Extrae_Java_Wait_end(void);
+
 void Extrae_Java_GarbageCollector_begin(void);
 void Extrae_Java_GarbageCollector_end(void);
 


### PR DESCRIPTION

1. Fixed installation bugs due to configuration errors (apparently, the example `JAVA/automatic` has never worked properly, since the functions inside the `function-list` file were never traced):
    - The AspectJ Weaver (`aspectjweaver.jar`) was never substituted in extraej, because of some bugs inside `config/java.m4` and `src/launcher/java/Makefile.am`
    - The AspectJ Runtime (`aspectjrt.jar`) needs to be found as well to make Aspects work in Java


2. Added feature in `extraej`. Now it's possible to run `.jar` files by adding `-jar` option.
