### PR TITLE
Use command instead of the full path

### DIFF
--- a/substitute
+++ b/substitute
@@ -16,7 +16,7 @@ UNAME=`uname`
 if [ "${UNAME}" = "Darwin" -o "${UNAME}" = "AIX" ] ; then
 	TMPFILE=substitute-$$
 	${SED} "s|${KEY}|${VALUE}|g" < ${FILE} >${TMPFILE}
-	/bin/mv -f ${TMPFILE} ${FILE}
+	command mv -f ${TMPFILE} ${FILE}
 else
 	${SED} "s|${KEY}|${VALUE}|g" -i ${FILE}
 fi

--- a/substitute-all
+++ b/substitute-all
@@ -23,5 +23,5 @@ fi
 
 echo "Applying modification in ${PATHTOCHANGE} - Key = ${KEY} for value = ${VALUE}"
 
-/usr/bin/find ${PATHTOCHANGE} -type f -exec ${SCRIPT_LOCATION} "${SED}" "${KEY}" "${VALUE}" {} \;
+command find ${PATHTOCHANGE} -type f -exec ${SCRIPT_LOCATION} "${SED}" "${KEY}" "${VALUE}" {} \;
 


### PR DESCRIPTION
When installing extrae in nix, the `mv` and `find` commands are not installed in /usr/bin or /bin, so the build process fails but they are available in the `$PATH`. They `command` builtin looks for them in `$PATH`, so any aliases are not used, following the behavior of writing the absolute path. The `command` builtin is defined in [the POSIX standard]( https://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html) for the `sh` shell since the issue 4 (1994).