### PR TITLE
Python tracing: fixed bug when EXTRAE_PY_CEVENTS is not defined

### DIFF
--- a/src/others/pyextrae/common/extrae.py.in
+++ b/src/others/pyextrae/common/extrae.py.in
@@ -23,7 +23,7 @@ if (ExtraeHomeEnv):
 
 CEventsEnv     = os.getenv("EXTRAE_PY_CEVENTS")
 TraceCEvents   = False
-if (CEventsEnv.lower() == "yes") or (CEventsEnv.lower() == "enabled") or (CEventsEnv.lower() == "true") or (CEventsEnv == "1"):
+if (CEventsEnv is not None) and ((CEventsEnv.lower() == "yes") or (CEventsEnv.lower() == "enabled") or (CEventsEnv.lower() == "true") or (CEventsEnv == "1")):
   TraceCEvents = True
 
 LibrarySeq     = ExtraeHome + "/lib/libseqtrace.so"


### PR DESCRIPTION
Fixed a bug when if **EXTRAE_PY_CEVENTS** env variable doesn't exist, then Python's runtime complains with an exception:
```
Traceback (most recent call last):
  File "./foo_naive.py", line 5, in <module>
    import pyextrae.sequential as pyextrae
  File "/home/orudyy/local/extrae-3.8.3/install/libexec/pyextrae/sequential/__init__.py", line 1, in <module>
    from pyextrae.common.extrae import *
  File "/home/orudyy/local/extrae-3.8.3/install/libexec/pyextrae/common/extrae.py", line 26, in <module>
    if  ((CEventsEnv.lower() == "yes") or (CEventsEnv.lower() == "enabled") or (CEventsEnv.lower() == "true") or (CEventsEnv == "1")):
AttributeError: 'NoneType' object has no attribute 'lower'
```