### PR TITLE
Update object_tree.c

### DIFF
--- a/src/merger/common/object_tree.c
+++ b/src/merger/common/object_tree.c
@@ -302,7 +302,7 @@ void ObjectTable_dumpAddresses (FILE *fd, unsigned eventstart)
 
 			fprintf (fd, "EVENT_TYPE\n");
 			fprintf (fd, "0 %u Object addresses for task %u.%u\n", eventstart++, _ptask, _task);
-			fprintf (fd, "VALUES\n");
+			fprintf (fd, "%s\n0   %s\n", "VALUES", "End");
 
 			/* For now, emit only data symbols for binary object 0 */
 			for (_address = 0; _address < task_info->binary_objects[0].nDataSymbols; _address++)


### PR DESCRIPTION
The following error is avoided with this patch while reading the pcf file on Paraver:
parse error at file - line 225 column 7
'VALUES'
       ^- here
Expected: <expect_operator><numeric_index><phrase>
wxparaver.bin: Fatal IO error 0 (Success) on X server localhost:34.0.