### PR TITLE
Adds new option (-emit-raw-callstacks) to mpi2prv

### DIFF
--- a/src/merger/common/mpi2out.c
+++ b/src/merger/common/mpi2out.c
@@ -917,6 +917,11 @@ void ProcessArgs (int rank, int argc, char *argv[])
 			set_option_merge_RemoveFiles (FALSE);
 			continue;
 		}
+		if (!strcmp (argv[CurArg], "-emit-raw-callstack"))
+		{
+			set_option_merge_EmitRAWCallstack (TRUE);
+			continue;
+		}
 		if (!strcmp (argv[CurArg], "--"))
 		{
 			cur_ptask++;

--- a/src/merger/common/options.c
+++ b/src/merger/common/options.c
@@ -147,3 +147,6 @@ static int option_merge_EmitLibraryEvents = FALSE;
 int get_option_merge_EmitLibraryEvents (void) { return option_merge_EmitLibraryEvents; }
 void set_option_merge_EmitLibraryEvents (int b) { option_merge_EmitLibraryEvents = b; }
 
+static int option_merge_EmitRAWCallstack = FALSE;
+int get_option_merge_EmitRAWCallstack (void) { return option_merge_EmitRAWCallstack; }
+void set_option_merge_EmitRAWCallstack (int b) { option_merge_EmitRAWCallstack = b; }

--- a/src/merger/common/options.h
+++ b/src/merger/common/options.h
@@ -116,4 +116,7 @@ void set_option_merge_TranslateAddresses (int b);
 int get_option_merge_EmitLibraryEvents (void);
 void set_option_merge_EmitLibraryEvents (int b);
 
+int get_option_merge_EmitRAWCallstack (void);
+void set_option_merge_EmitRAWCallstack (int b);
+
 #endif

--- a/src/merger/paraver/addr2info.c
+++ b/src/merger/paraver/addr2info.c
@@ -324,42 +324,83 @@ UINT64 Address2Info_Translate_MemReference (unsigned ptask, unsigned task, UINT6
 		char tmp[1024];
 		int i;
 
-		snprintf (buffer, sizeof(buffer), "");
+		if (!get_option_merge_EmitRAWCallstack())
+		{
+			snprintf (buffer, sizeof(buffer), "");
 
-		/* Trim head and tail for callers that can't be translated */
-		for (i = 0; i < MAX_CALLERS; i++)
-			if (calleraddresses[i] != 0)
-			{
-				Translate_Address (calleraddresses[i], ptask, task, &module,
-				  &sname, &filename, &line);
-				if (!strcmp (filename, ADDR_UNRESOLVED) || !strcmp (filename, ADDR_NOT_FOUND))
-					calleraddresses[i] = 0;
-				else
-					break;
-			}
+			/* Trim head and tail for callers that can't be translated */
+			for (i = 0; i < MAX_CALLERS; i++)
+				if (calleraddresses[i] != 0)
+				{
+					Translate_Address (calleraddresses[i], ptask, task, &module,
+					  &sname, &filename, &line);
+					if (!strcmp (filename, ADDR_UNRESOLVED) || !strcmp (filename, ADDR_NOT_FOUND))
+						calleraddresses[i] = 0;
+					else
+						break;
+				}
 
-		for (i = MAX_CALLERS-1; i >= 0; i--)
-			if (calleraddresses[i] != 0)
-			{
-				Translate_Address (calleraddresses[i], ptask, task, &module,
-				  &sname, &filename, &line);
-				if (!strcmp (filename, ADDR_UNRESOLVED) || !strcmp (filename, ADDR_NOT_FOUND))
-					calleraddresses[i] = 0;
-				else
-					break;
-			}
+			for (i = MAX_CALLERS-1; i >= 0; i--)
+				if (calleraddresses[i] != 0)
+				{
+					Translate_Address (calleraddresses[i], ptask, task, &module,
+					  &sname, &filename, &line);
+					if (!strcmp (filename, ADDR_UNRESOLVED) || !strcmp (filename, ADDR_NOT_FOUND))
+						calleraddresses[i] = 0;
+					else
+						break;
+				}
 
-		for (i = 0; i < MAX_CALLERS; i++)
-			if (calleraddresses[i] != 0)
+			for (i = 0; i < MAX_CALLERS; i++)
+				if (calleraddresses[i] != 0)
+				{
+					Translate_Address (calleraddresses[i], ptask, task, &module,
+					  &sname, &filename, &line);
+					if (strlen(buffer) > 0)
+						snprintf (tmp, sizeof(tmp), " > %s:%d", filename, line);
+					else
+						snprintf (tmp, sizeof(tmp), "%s:%d", filename, line);
+					strncat (buffer, tmp, sizeof(buffer));
+				}
+		}
+		else
+		{
+			// Export the id for a dynamically allocated object in memory through its callstack
+			// as pointers (not translated references). The pointers refer to the address in the
+			// respective library where it belongs as providing the absolute address won't help
+			// (even if ASLR is disabled) because LD_PRELOADing alters the addresses from the libs
+			// Main binary addresses are given with absolute references
+			const char * mainbinary = ObjectTable_GetBinaryObjectName (ptask, task);
+			UINT64 base_address;
+			buffer[0] = (char)0;
+			for (i = 0; i < MAX_CALLERS; i++)
 			{
-				Translate_Address (calleraddresses[i], ptask, task, &module,
-				  &sname, &filename, &line);
-				if (strlen(buffer) > 0)
-					snprintf (tmp, sizeof(tmp), " > %s:%d", filename, line);
-				else
-					snprintf (tmp, sizeof(tmp), "%s:%d", filename, line);
-				strncat (buffer, tmp, sizeof(buffer));
+				if (calleraddresses[i] != 0)
+				{
+					binary_object_t * obj = ObjectTable_GetBinaryObjectAt (ptask, task, calleraddresses[i]);
+					const char * module;
+
+					if (obj != NULL)
+					{
+						module = obj->module;
+						base_address = (strcmp (mainbinary, module) != 0) ? obj->start_address : 0;
+					}
+					else
+					{
+						if (getenv("EXTRAE_DEBUG"))
+							fprintf (stderr, "DEBUG: cannot translate address %08lx \n", calleraddresses[i]);
+						module = "Unknown";
+						base_address = 0;
+					}
+
+					if (strlen(buffer) > 0)
+						snprintf (tmp, sizeof(tmp), " > %s!%08lx", module, calleraddresses[i] - base_address);
+					else
+						snprintf (tmp, sizeof(tmp), "%s!%08lx", module, calleraddresses[i] - base_address);
+					strncat (buffer, tmp, sizeof(buffer));
+				}
 			}
+		}
 
 		return 1+AddressTable_Insert_MemReference (query, module, "",
 		  strdup(buffer), 0);


### PR DESCRIPTION
When -emit-raw-callstacks is enabled callstacks are not translated with binutils but left as a pair <library, symbol-offset-within-library>