### PR TITLE
autoconf: basic cross-compilation fixes

### DIFF
--- a/config/macros.m4
+++ b/config/macros.m4
@@ -433,47 +433,13 @@ dnl AX_FLAGS_SAVE()
   dnl AX_FLAGS_RESTORE()
 ])
 
-
-# AX_CHECK_POINTER_SIZE
-# ---------------------
-AC_DEFUN([AX_CHECK_POINTER_SIZE],
-[
-   AC_REQUIRE([AX_IS_BGL_MACHINE])
-   AC_REQUIRE([AX_IS_BGP_MACHINE])
-   AC_REQUIRE([AX_IS_BGQ_MACHINE])
-
-   if test "${IS_BGQ_MACHINE}" = "yes" ; then
-      POINTER_SIZE=64
-   elif test "${IS_BGL_MACHINE}" = "yes" -o "${IS_BGP_MACHINE}" = "yes" ; then
-      POINTER_SIZE=32
-   elif test "${IS_MIC_MACHINE}" = "yes" ; then
-      POINTER_SIZE=64
-   elif test "${IS_ARM_MACHINE}" = "yes" ; then
-      POINTER_SIZE=32
-   elif test "${IS_ARM64_MACHINE}" = "yes" ; then
-      POINTER_SIZE=64
-   elif test "${IS_SPARC64_MACHINE}" = "yes" ; then
-      POINTER_SIZE=64
-   else
-      AC_TRY_RUN(
-         [
-            int main()
-            {
-               return sizeof(void *)*8;
-            }
-         ],
-         [ POINTER_SIZE="0" ],
-         [ POINTER_SIZE="$?"]
-      )
-   fi
-])
-
-
 # AX_SELECT_BINARY_TYPE
 # ---------------------
 # Check the binary type the user wants to build and verify whether it can be successfully built
 AC_DEFUN([AX_SELECT_BINARY_TYPE],
 [
+	AC_CHECK_SIZEOF([void *])
+
 	AC_ARG_WITH(binary-type,
 		AC_HELP_STRING(
 			[--with-binary-type@<:@=ARG@:>@],
@@ -498,8 +464,7 @@ AC_DEFUN([AX_SELECT_BINARY_TYPE],
 			[for $_AC_LANG_PREFIX[]_compiler compiler default binary type], 
 			[[]_AC_LANG_PREFIX[]_ac_cv_compiler_default_binary_type],
 			[
-				AX_CHECK_POINTER_SIZE
-				Default_Binary_Type="$POINTER_SIZE"
+				Default_Binary_Type=$(( 8 * ${ac_cv_sizeof_void_p} ))
 				[]_AC_LANG_PREFIX[]_ac_cv_compiler_default_binary_type="$Default_Binary_Type""-bit"
 			]
 		)
@@ -540,8 +505,7 @@ AC_DEFUN([AX_SELECT_BINARY_TYPE],
 				old_[]_AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS"
 				[]_AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $flag"
 
-				AX_CHECK_POINTER_SIZE()
-				if test "$POINTER_SIZE" = "$Selected_Binary_Type" ; then
+				if test $(( 8 * ${ac_cv_sizeof_void_p})) = "${Selected_Binary_Type}" ; then
 					AC_MSG_RESULT([$flag])
 					break
 				else

--- a/config/macros.m4
+++ b/config/macros.m4
@@ -544,31 +544,10 @@ AC_DEFUN([AX_ENSURE_CXX_PRESENT],
 # Test if the architecture is little or big endian
 AC_DEFUN([AX_CHECK_ENDIANNESS],
 [
-   AC_CACHE_CHECK([for the architecture endianness], [ac_cv_endianness],
-   [
-      AC_LANG_SAVE()
-      AC_LANG([C])
-      AC_TRY_RUN(
-      [
-         int main()
-         {
-            short s = 1;
-            short * ptr = &s;
-            unsigned char c = *((char *)ptr);
-            return c;
-         }
-      ],
-      [ac_cv_endianness="big endian" ],
-      [ac_cv_endianness="little endian" ]
-      )
-      AC_LANG_RESTORE()
-   ])
-   if test "$ac_cv_endianness" = "big endian" ; then
-      AC_DEFINE(IS_BIG_ENDIAN, 1, [Define to 1 if architecture is big endian])
-   fi
-   if test "$ac_cv_endianness" = "little endian" ; then
-      AC_DEFINE(IS_LITTLE_ENDIAN, 1, [Define to 1 if architecture is little endian])
-   fi
+   AC_C_BIGENDIAN(
+      AC_DEFINE(IS_BIG_ENDIAN, 1, [Define to 1 if architecture is big endian]),
+      AC_DEFINE(IS_LITTLE_ENDIAN, 1, [Define to 1 if architecture is little endian]),
+      AC_MSG_FAILURE([Cannot detect endianiness]))
 ])
 
 


### PR DESCRIPTION
This fixes 2 major cross-compiling issues (as commented in #72). With this patch we can cross-compile at least the extrae version without external libraries, so hopefully we'd be able to merge https://github.com/JuliaPackaging/Yggdrasil/pull/5710 .

MPI and xml2 cross-compile configuration issues mentioned in #72 are left outstanding. I have some code that fixes the MPI part but I wasn't able to test the solution on my computer because configure is stubbornly refusing to find debian's openmpi headers for some reason. (Any advice welcome :D ).

On a note, I killed the specific BGQ/BGL/MIC/ARM/.... machine tests because hopefully the pointer sizes should be derivable directly; if there are exceptions (`pointer size != sizeof(void*)`) please lmk.

Thanks!

cc @arnaumontagud @clasqui @laurentheirendt