### PR TITLE
Enable cross-compilation to `powerpc64le` architecture

### DIFF
--- a/config/macros.m4
+++ b/config/macros.m4
@@ -454,6 +454,8 @@ AC_DEFUN([AX_CHECK_POINTER_SIZE],
       POINTER_SIZE=64
    elif test "${IS_SPARC64_MACHINE}" = "yes" ; then
       POINTER_SIZE=64
+   elif test "${IS_POWERPC64LE_MACHINE}" = "yes" ; then
+      POINTER_SIZE=64    
    else
       AC_TRY_RUN(
          [

--- a/config/system.m4
+++ b/config/system.m4
@@ -68,6 +68,20 @@ AC_DEFUN([AX_SYSTEM_TYPE],
 		target_os="linux"
 	fi
 
+	AC_ARG_ENABLE(powerpc64le,
+	   AC_HELP_STRING(
+		  [--enable-powerpc64le],
+		  [Enable compilation for powerpc64le architecture (disabled by default; needed when cross-compiling for powerpc64le)]
+	   ),
+	   [enable_powerpc64le="${enableval}"],
+	   [enable_powerpc64le="no"]
+	)
+	IS_POWERPC64LE_MACHINE=${enable_powerpc64le}
+	if test "${IS_POWERPC64LE_MACHINE}" = "yes" ; then
+		target_cpu="powerpc64le"
+		target_os="linux"
+	fi
+
 	# Check if this is an Altix machine and if it has an /dev/mmtimer device
 	# (which is a global clock!)
 	AC_ARG_ENABLE(check-altix,

--- a/configure.ac
+++ b/configure.ac
@@ -543,6 +543,17 @@ elif test "${IS_SPARC64_MACHINE}" = "yes" ; then
 	voidp_size=8
 	short_size=2
 	char_size=1
+elif test "${IS_POWERPC64LE_MACHINE}" = "yes" ; then
+	cross_compiling="yes"
+	long_long_size=8
+	long_size=8
+	int_size=4
+	pid_t_size=4
+	ssize_t_size=8
+	size_t_size=8
+	voidp_size=8
+	short_size=2
+	char_size=1
 else
 	cross_compiling="no" # Force AC_CHECK_SIZEOF calculate these values
 	long_long_size=0


### PR DESCRIPTION
This fixes one cross-compilation issue when trying to cross-compile to `powerpc64le` architecture, as explained in JuliaPackaging/Yggdrasil#5991.