### PR TITLE
Remove use of Instruction::Ptr

### DIFF
--- a/src/launcher/dyninst/commonSnippets.C
+++ b/src/launcher/dyninst/commonSnippets.C
@@ -482,10 +482,17 @@ string decodeBasicBlocks(BPatch_function * function, string routine)
         ParseAPI::Block* b  = ParseAPI::convert(block);
         void * buf  = b->region()->getPtrToInstruction(b->start());
         InstructionAPI::InstructionDecoder dec((unsigned char*)buf,b->size(),b->region()->getArch());
+#if defined(DYNINST_DECODE_RETURNS_PTR)
+        InstructionAPI::Instruction::Ptr insn;
+        while((insn = dec.decode())) {
+            res <<loop_name<<"# "<<line++<<": "<< insn->format() << endl;
+        }
+#else
         InstructionAPI::Instruction insn;
         while((insn = dec.decode()).isValid()) {
             res <<loop_name<<"# "<<line++<<": "<< insn.format() << endl;
         }
+#endif // defined(DYNINST_DECODE_RETURNS_PTR)
     }
     return res.str();
 }


### PR DESCRIPTION
Since commit dyninst/dyninst@9157d8a0595b355d8604d61a40a40dac577df7e2, the `Instruction::Ptr` type has been removed from Dyninst. Reflect this change onto extrae.

It may need to be adapted to check the version of dyninst used in order to keep backward compatibility. Still, I keep this PR open for other users who may run into the same issue I encountered.