### PR TITLE
Add propsal for the value-range problem mentioned in #110

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -593,6 +593,7 @@ AC_CONFIG_FILES([\
   tests/functional/merger/Makefile \
   tests/functional/merger/dump-events/Makefile \
   tests/functional/merger/shared-libraries/Makefile \
+  tests/functional/merger/value-range/Makefile \
   tests/functional/xml/Makefile \
   tests/functional/hw-counters/Makefile \
   tests/functional/callstack/Makefile \

--- a/src/merger/paraver/labels.c
+++ b/src/merger/paraver/labels.c
@@ -757,14 +757,17 @@ void Labels_loadSYMfile (int taskid, int allobjects, unsigned ptask,
 
 				case 'd':
 				{
-					int res, eventvalue;
+					int res;
+					extrae_value_t eventvalue;
 					char value_description[1024];
 					value_t * evt_value = NULL;
-					unsigned i, max = Extrae_Vector_Count (&last_event_type_used->event_values);
+					unsigned i, max = Extrae_Vector_Count(&last_event_type_used->event_values);
 
-					res = sscanf (LINE, "%d \"%[^\"]\"", &eventvalue, value_description);
+					res = sscanf (LINE, "%llu \"%[^\"]\"", &eventvalue, value_description);
+					printf("read value: %llu", eventvalue);
 					if (res != 2) fprintf (stderr, PACKAGE_NAME": Error! Invalid line ('%s') in %s\n", LINE, name);
                         
+
 					for (i = 0; i < max; i++)
 					{
 						value_t * evt = Extrae_Vector_Get (&last_event_type_used->event_values, i);
@@ -772,7 +775,7 @@ void Labels_loadSYMfile (int taskid, int allobjects, unsigned ptask,
 						{
 							if(strcmp(evt->label, value_description))
 							{
-								fprintf(stderr, PACKAGE_NAME"(%s,%d): Warning! Ignoring duplicate definition \"%s\" for value type %d,%d!\n",__FILE__, __LINE__, value_description,last_event_type_used->event_type.type, eventvalue);
+								fprintf(stderr, PACKAGE_NAME"(%s,%d): Warning! Ignoring duplicate definition \"%s\" for value type %d,%llu!\n",__FILE__, __LINE__, value_description,last_event_type_used->event_type.type, eventvalue);
 							}
 							evt_value = evt;
 							break;
@@ -843,13 +846,14 @@ void Labels_loadSYMfile (int taskid, int allobjects, unsigned ptask,
 
 				case 'b': // BasicBlocks symbol
 				{
-					int res, eventvalue;
+					int res;
+					extrae_value_t eventvalue;
 					char bb_description[1024];
 					unsigned i, max = Extrae_Vector_Count (&defined_basic_block_labels);
 					event_type_t * evt_type = NULL;
 					value_t * evt_value = NULL;
 
-					res = sscanf (LINE, "%d \"%[^\"]\"", &eventvalue, bb_description);
+					res = sscanf (LINE, "%llu \"%[^\"]\"", &eventvalue, bb_description);
 					if (res != 2) fprintf (stderr, PACKAGE_NAME": Error! Invalid line ('%s') in %s\n", LINE, name);
 					if (max==0)
 					{
@@ -872,7 +876,7 @@ void Labels_loadSYMfile (int taskid, int allobjects, unsigned ptask,
 						{
 							if (strcmp(evt->label, bb_description))
 							{
-								fprintf(stderr, "Extrae (%s,%d): Warning! Ignoring duplicate definition \"%s\" for value type %d,%d!\n",__FILE__, __LINE__, bb_description,evt_type->event_type.type, eventvalue);
+								fprintf(stderr, "Extrae (%s,%d): Warning! Ignoring duplicate definition \"%s\" for value type %d,%llu!\n",__FILE__, __LINE__, bb_description,evt_type->event_type.type, eventvalue);
 							}
 							evt_value = evt;
 							break;
@@ -1005,7 +1009,7 @@ void Write_UserDefined_Labels(FILE * pcf_fd)
             for (j = 0; j < max_values; j++)
             {
                 value_t * values = Extrae_Vector_Get (&evt->event_values, j);
-                fprintf (pcf_fd, "%d      %s\n", values->value, values->label);
+                fprintf (pcf_fd, "%llu      %s\n", values->value, values->label);
             }
         }
         LET_SPACES (pcf_fd);
@@ -1027,7 +1031,7 @@ void Write_BasickBlock_Labels(FILE * pcf_fd)
             for (j = 0; j < max_values; j++)
             {
                 value_t * values = Extrae_Vector_Get (&evt->event_values, j);
-                fprintf (pcf_fd, "%d      %s\n", values->value, values->label);
+                fprintf (pcf_fd, "%llu      %s\n", values->value, values->label);
             }
         }
         LET_SPACES (pcf_fd);

--- a/src/merger/paraver/labels.h
+++ b/src/merger/paraver/labels.h
@@ -28,6 +28,7 @@
 #include "events.h"
 #include "xalloc.h"
 #include <extrae_vector.h>
+#include <extrae_types.h>
 
 typedef enum {
 	CODELOCATION_FUNCTION,
@@ -86,7 +87,7 @@ evttype_t;
 #define VALUE_LBL   256
 typedef struct value_t
 {
-  int value;
+  extrae_value_t value;
   char label[VALUE_LBL];
 }
 value_t;

--- a/tests/functional/merger/Makefile.am
+++ b/tests/functional/merger/Makefile.am
@@ -1,4 +1,5 @@
 SUBDIRS = \
  dump-events \
- shared-libraries
+ shared-libraries \
+ value-range
 

--- a/tests/functional/merger/value-range/Makefile.am
+++ b/tests/functional/merger/value-range/Makefile.am
@@ -1,0 +1,19 @@
+include $(top_srcdir)/PATHS
+
+check_PROGRAMS = main
+main_SOURCES = main.c
+
+TESTS = test-value-range.sh
+
+TESTS_ENVIRONMENT = \
+  EXTRAE_HOME=$(top_builddir)
+
+EXTRA_DIST = \
+  test-value-range.sh
+
+main$(EXEEXT): main.c
+	gcc -g $^ -Wl,-rpath -Wl,../../../../src/tracer/.libs -Wl,-rpath -Wl,. -L ../../../../src/tracer/.libs -lseqtrace -o $@
+
+clean-local:
+	-rm -rf set-0/ TRACE.mpits main.{pcf,prv,row}
+	-rm -rf lib*

--- a/tests/functional/merger/value-range/main.c
+++ b/tests/functional/merger/value-range/main.c
@@ -1,0 +1,15 @@
+#include <extrae.h>
+#include <limits.h>
+#include <stdio.h>
+int main(){
+        Extrae_init();
+        extrae_value_t value = ULLONG_MAX -1; // ULLONG_MAX -1 = 18446744073709551614
+        extrae_type_t type=100;
+        printf("Extrae Value: %llu, %u", value, type);
+        Extrae_event(type,value);
+        extrae_value_t values[2]={0,value};
+        char * descriptions[2] = {"zero","max_value-1"};
+        unsigned nValues=2;
+        Extrae_define_event_type (&type,"ownEventType",&nValues, values, descriptions);
+        Extrae_fini();
+}

--- a/tests/functional/merger/value-range/test-value-range.sh
+++ b/tests/functional/merger/value-range/test-value-range.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source ../../helper_functions.bash
+
+TRACE=main
+
+EXTRAE_ON=1 ./main
+../../../../src/merger/mpi2prv -f TRACE.mpits
+
+# Do actual checks
+CheckEntryInPCF ${TRACE}.pcf "18446744073709551614"
+


### PR DESCRIPTION
This PR introduces a possible fix for the issue described in #110 

I also included a small test to test the generation of the correct `.pcf` file. 

I already discovered, that paraver seems to also has some problems reading the `.pcf` file correctly, as well as displaying the trace correctly.  I just opened the corresponding issue in the paraver repository: https://github.com/bsc-performance-tools/wxparaver/issues/19