### PR TITLE
Preprocessor logic in paraver_generator.c fails when HAVE_ZLIB

### DIFF
--- a/src/merger/paraver/paraver_generator.c
+++ b/src/merger/paraver/paraver_generator.c
@@ -1320,7 +1320,7 @@ int Paraver_JoinFiles (unsigned num_appl, char *outName, FileSet_t * fset,
 		    	exit(-1);
 		    }
 		} else
-#else
+#endif // HAVE_ZLIB
 		{
 # if HAVE_FOPEN64
 		    prv_fd.handle = fopen64(outName, "w");
@@ -1335,7 +1335,6 @@ int Paraver_JoinFiles (unsigned num_appl, char *outName, FileSet_t * fset,
 		    	exit(-1);
 		    }
 		}
-#endif // HAVE_ZLIB
 	} /* taskid == 0 */
 
 	error = Paraver_WriteHeader (fset, numtasks, taskid, num_appl, Ftime, prv_fd,


### PR DESCRIPTION
The preprocessor loop at paraver_generator.c:1310 did not compile when HAVE_ZLIB is set because the "else" was not closed. This repairs the situation while keeping with what I think was the original logic: if zlib is available then test for isGzip or open a handle, and if not then just open a standard handle.