### PR TITLE
Fix flexible array members in event_t, HWC_Set_t

### DIFF
--- a/src/common/record.h
+++ b/src/common/record.h
@@ -78,12 +78,12 @@ typedef struct
   u_param param;                 /* Parameters of this event              */
   UINT64 value;                  /* Value of this event                   */
   UINT64 time;                   /* Timestamp of this event               */
-#if 1 || USE_HARDWARE_COUNTERS || defined(HETEROGENEOUS_SUPPORT)
-  long long HWCValues[MAX_HWC];      /* Hardware counters read for this event */
-#endif
   INT32 event;                   /* Type of this event                    */
 #if 1 || USE_HARDWARE_COUNTERS || defined(HETEROGENEOUS_SUPPORT)
   INT32 HWCReadSet;              /* Marks which set of counters was read, if any */
+#endif
+#if 1 || USE_HARDWARE_COUNTERS || defined(HETEROGENEOUS_SUPPORT)
+  long long HWCValues[MAX_HWC];      /* Hardware counters read for this event */
 #endif
 } event_t;
 

--- a/src/tracer/hwc/common_hwc.h
+++ b/src/tracer/hwc/common_hwc.h
@@ -42,7 +42,6 @@ struct HWC_Set_t
     pm_prog_t pmprog;
     int group;
 #endif
-    int counters[MAX_HWC];
     int num_counters;
     unsigned long long change_at;
     enum ChangeType_t change_type;
@@ -51,6 +50,7 @@ struct HWC_Set_t
     int *OverflowCounter;
     int NumOverflows;
 #endif
+    int counters[MAX_HWC];
 };
 
 // Define a safe default if PAPI is not available


### PR DESCRIPTION
Since C99, flexible array members have been required to be the last member of a structure type.

6.7.2.1 Structure and union specifiers

Constraints (16)

  As a special case, the last element of a structure with more than one
  named member may have an incomplete array type; this is called a
  flexible array member.

---

```
$ gcc --version
gcc (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


$ ../configure --disable-doc --without-mpi --without-unwind --without-papi --with-dyninst=/path/to/dyninst --with-elfutils=/usr --with-elfutils-libs=/usr/lib --with-tbb=/usr --with-tbb-libs=/usr/lib --with-boost=/usr --with-boost-libs=/usr/lib --with-xml=/usr --with-xml2-libs=/usr/lib --with-xml2-headers=/usr/include

$ make

In file included from paraver/file_set.h:33,
from paraver/paraver_generator.c:65:
../../src/common/record.h:82:13: error: flexible array member not at end of struct
82 |   long long HWCValues[MAX_HWC];      /* Hardware counters read for this event */
```
